### PR TITLE
Enable multiple Phidgets of the same type

### DIFF
--- a/phidgetAPI.js
+++ b/phidgetAPI.js
@@ -74,11 +74,14 @@ function phidgetConnection(){
 
                 phidget.client.write('report 8 report\r\n');
 
-                phidget.client.write(
-                    'set /PCK/Client/0.0.0.0/1/'+
-                    phidget.params.type+
-                    '="Open" for session\r\n'
-                );
+				var randInt = parseInt(Math.random() * 99999, 10),
+					openStr = 'set /PCK/Client/0.0.0.0/' + randInt + '/' + phidget.params.type + '="Open" for session\r\n',
+					listenStr = 'listen /PSK/' + phidget.params.type + ' lid0\r\n';
+				if (phidget.params.boardID) {
+					openStr = 'set /PCK/Client/0.0.0.0/' + randInt + '/' + phidget.params.type + '/' + phidget.params.boardID + '="Open" for session\r\n';
+					listenStr = 'listen /PSK/' + phidget.params.type + '//' + phidget.params.boardID + ' lid0\r\n';
+				}	
+                phidget.client.write(openStr);
                 
                 if(phidget.params.type=='PhidgetManager'){
                     phidget.client.write(
@@ -88,11 +91,7 @@ function phidgetConnection(){
                     return;
                 }
                 
-                phidget.client.write(
-                    'listen /PSK/'+
-                    phidget.params.type+
-                    ' lid0\r\n'
-                );
+                phidget.client.write(listenStr);
                 
             }
         );	

--- a/readme.markdown
+++ b/readme.markdown
@@ -57,6 +57,7 @@ __phidgets.quit()__ This method requests a disconnect from the phidget board.  T
 		version : '1.0.10', //older phidgetwebservice installs may require 1.0.9
 		password: null,
 		type    : 'PhidgetManager',
+		boardID : 123456, //optional - used to connect to multiple boards of the same type
 		rawLog  : false
 	}
 


### PR DESCRIPTION
Phidget webservice connect changed to create a unique ID when using multiple Phidgets of the same type. Uses boardID in the connect params.

i.e. PhidgetInterfaceKit 8/8/8 and 0/0/8